### PR TITLE
fix: google cloud print error

### DIFF
--- a/src/com/artifex/mupdfdemo/PrintDialogActivity.java
+++ b/src/com/artifex/mupdfdemo/PrintDialogActivity.java
@@ -12,6 +12,7 @@ import android.util.Base64;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
+import android.webkit.JavascriptInterface;
 
 public class PrintDialogActivity extends Activity {
 	private static final String PRINT_DIALOG_URL = "https://www.google.com/cloudprint/dialog.html";
@@ -65,15 +66,19 @@ public class PrintDialogActivity extends Activity {
 		}
 	}
 
+	// https://stackoverflow.com/questions/27601733/cant-print-from-device
 	final class PrintDialogJavaScriptInterface {
+		@JavascriptInterface
 		public String getType() {
 			return cloudPrintIntent.getType();
 		}
 
+		@JavascriptInterface
 		public String getTitle() {
 			return cloudPrintIntent.getExtras().getString("title");
 		}
 
+		@JavascriptInterface
 		public String getContent() {
 			try {
 				ContentResolver contentResolver = getContentResolver();
@@ -99,10 +104,12 @@ public class PrintDialogActivity extends Activity {
 			return "";
 		}
 
+		@JavascriptInterface
 		public String getEncoding() {
 			return CONTENT_TRANSFER_ENCODING;
 		}
 
+		@JavascriptInterface
 		public void onPostMessage(String message) {
 			if (message.startsWith(CLOSE_POST_MESSAGE_NAME)) {
 				setResult(resultCode);


### PR DESCRIPTION
I found a fix for an open issue with the cordova-plugin-document-viewer, see https://github.com/sitewaerts/cordova-plugin-document-viewer/issues/99.

Before this fix i received following error after pressing the print button in the google cloud printing dialog.

> I/chromium: [INFO:CONSOLE(313)] "Uncaught TypeError: Cannot read property 'o' of null", source: https://www.google.com/cloudprint/client/2161142221-dialog_mobile__de.js (313)

I found the solution on a few stackoverflow questions:

- https://stackoverflow.com/questions/36617847/uncaught-typeerror-cannot-read-property-o-of-null-google-print-android
- https://stackoverflow.com/questions/27601733/cant-print-from-device

Is it possible for you to release a new version of the Cleverdox Viewer App, with the fix in it? Of course, after you have checked whether everything works on your side.

It would be a shame if we had to drop the cordova-plugin-document-viewer, only because of the not working print function.

**Edit**:   The annotation was added in API 17, so propably the target and min sdk of the project need some changes. Also the annotation is needed for api > 16. (see https://developer.android.com/reference/android/webkit/JavascriptInterface.html) 